### PR TITLE
parallel can handle non-Promise values

### DIFF
--- a/src/parallel.ts
+++ b/src/parallel.ts
@@ -1,3 +1,4 @@
+import {isFunction} from './utils/isFunction';
 import {isPromise} from './utils/isPromise';
 
 /* eslint-disable @typescript-eslint/no-invalid-this */
@@ -15,12 +16,12 @@ export interface ParallelResult<T> {
 }
 
 
-export async function parallel<T>(promises: (parallel.Parallelizable<T>|Promise<T>)[]): Promise<ParallelResult<T>> {
+export async function parallel<T>(promises: (T | parallel.Parallelizable<T> | Promise<T>)[]): Promise<ParallelResult<T>> {
   const wrapper = promises.map(async (p, index) => {
     try {
-      const value: T = isPromise<T>(p)
-        ? await p
-        : await p();
+      const value: T = isFunction(p)
+        ? await p()
+        : await p;
       return {fulfilled: true, value, index};
     } catch (e) {
       let error: Error;
@@ -81,7 +82,7 @@ export async function parallel<T>(promises: (parallel.Parallelizable<T>|Promise<
 }
 
 export namespace parallel {
-  export type Parallelizable<T> = () => Promise<T>|T;
+  export type Parallelizable<T> = () => Promise<T> | T;
   export type ResolutionStatus = {fulfilled: boolean};
   export type Fulfillment<T> = ResolutionStatus & {value: T, error: null, index: number};
   export type Rejection = ResolutionStatus & {error: Error, value: null, index: number};

--- a/src/parallel.ts
+++ b/src/parallel.ts
@@ -1,5 +1,4 @@
 import {isFunction} from './utils/isFunction';
-import {isPromise} from './utils/isPromise';
 
 /* eslint-disable @typescript-eslint/no-invalid-this */
 

--- a/src/parallel_spec.ts
+++ b/src/parallel_spec.ts
@@ -133,4 +133,32 @@ describe('parallel', () => {
       });
     });
   });
+
+  describe('given non-promise values', () => {
+    const smorgasborg = [
+      'foo',
+      42,
+      false,
+      null,
+      {},
+      []
+    ];
+
+    it('returns standard objects and scalars', async () => {
+      const results = await parallel<any>(smorgasborg);
+      expect(results.items.map((item) => item.value)).toEqual(smorgasborg);
+    });
+
+    it('will handle functions that return non-promise values', async () => {
+      const smorgasborgFns: parallel.Parallelizable<any>[] = smorgasborg.map((value) => () => value);
+      const results = await parallel<any>(smorgasborgFns);
+      expect(results.items.map((item) => item.value)).toEqual(smorgasborg);
+    });
+
+    it('will handle functions that return promises', async () => {
+      const smorgasborgAsyncFns: parallel.Parallelizable<any>[] = smorgasborg.map((value) => async () => value);
+      const results = await parallel<any>(smorgasborgAsyncFns);
+      expect(results.items.map((item) => item.value)).toEqual(smorgasborg);
+    });
+  });
 });

--- a/src/utils/isFunction.ts
+++ b/src/utils/isFunction.ts
@@ -1,0 +1,3 @@
+export function isFunction(x: any): x is Function {
+  return typeof x === 'function';
+}

--- a/src/utils/isFunction.ts
+++ b/src/utils/isFunction.ts
@@ -1,3 +1,3 @@
 export function isFunction(x: any): x is Function {
-  return typeof x === 'function';
+  return (typeof x).endsWith('function');
 }


### PR DESCRIPTION
Parallel will currently mark any non-promise value as `rejected`, which is unlike how `Promise.all` behaves.

```javascript
const x = await Promise.all([1, 2, 3]);
// x === [1, 2, 3]
```